### PR TITLE
Add supported platforms

### DIFF
--- a/channels/sl-micro-60-baremetal.json
+++ b/channels/sl-micro-60-baremetal.json
@@ -9,7 +9,7 @@
             "metadata": {
                 "upgradeImage": "registry.suse.com/suse/sl-micro/6.0/baremetal-os-container:2.1.1-3.29",
                 "displayName": "SL Micro 6.0 OS",
-                "architectures": ["x86_64","aarch64"]
+                "platforms": ["linux/x86_64","linux/aarch64"]
             }
         }
     },
@@ -23,7 +23,7 @@
             "metadata": {
                 "uri": "registry.suse.com/suse/sl-micro/6.0/baremetal-iso-image:2.1.1-3.36",
                 "displayName": "SL Micro 6.0 ISO",
-                "architectures": ["x86_64","aarch64"]
+                "platforms": ["linux/x86_64","linux/aarch64"]
             }
         }
     }

--- a/channels/sl-micro-60-baremetal.json
+++ b/channels/sl-micro-60-baremetal.json
@@ -8,7 +8,8 @@
             "type": "container",
             "metadata": {
                 "upgradeImage": "registry.suse.com/suse/sl-micro/6.0/baremetal-os-container:2.1.1-3.29",
-                "displayName": "SL Micro 6.0 OS"
+                "displayName": "SL Micro 6.0 OS",
+                "architectures": ["amd64","arm64"]
             }
         }
     },
@@ -21,7 +22,8 @@
             "type": "iso",
             "metadata": {
                 "uri": "registry.suse.com/suse/sl-micro/6.0/baremetal-iso-image:2.1.1-3.36",
-                "displayName": "SL Micro 6.0 ISO"
+                "displayName": "SL Micro 6.0 ISO",
+                "architectures": ["amd64","arm64"]
             }
         }
     }

--- a/channels/sl-micro-60-baremetal.json
+++ b/channels/sl-micro-60-baremetal.json
@@ -9,7 +9,7 @@
             "metadata": {
                 "upgradeImage": "registry.suse.com/suse/sl-micro/6.0/baremetal-os-container:2.1.1-3.29",
                 "displayName": "SL Micro 6.0 OS",
-                "architectures": ["amd64","arm64"]
+                "architectures": ["x86_64","aarch64"]
             }
         }
     },
@@ -23,7 +23,7 @@
             "metadata": {
                 "uri": "registry.suse.com/suse/sl-micro/6.0/baremetal-iso-image:2.1.1-3.36",
                 "displayName": "SL Micro 6.0 ISO",
-                "architectures": ["amd64","arm64"]
+                "architectures": ["x86_64","aarch64"]
             }
         }
     }

--- a/channels/sl-micro-60-base.json
+++ b/channels/sl-micro-60-base.json
@@ -8,7 +8,8 @@
             "type": "container",
             "metadata": {
                 "upgradeImage": "registry.suse.com/suse/sl-micro/6.0/base-os-container:2.1.1-3.18",
-                "displayName": "SL Micro Base 6.0 OS"
+                "displayName": "SL Micro Base 6.0 OS",
+                "architectures": ["amd64","arm64"]
             }
         }
     },
@@ -21,7 +22,8 @@
             "type": "iso",
             "metadata": {
                 "uri": "registry.suse.com/suse/sl-micro/6.0/base-iso-image:2.1.1-2.47",
-                "displayName": "SL Micro Base 6.0 ISO"
+                "displayName": "SL Micro Base 6.0 ISO",
+                "architectures": ["amd64","arm64"]
             }
         }
     }

--- a/channels/sl-micro-60-base.json
+++ b/channels/sl-micro-60-base.json
@@ -9,7 +9,7 @@
             "metadata": {
                 "upgradeImage": "registry.suse.com/suse/sl-micro/6.0/base-os-container:2.1.1-3.18",
                 "displayName": "SL Micro Base 6.0 OS",
-                "architectures": ["x86_64","aarch64"]
+                "platforms": ["linux/x86_64","linux/aarch64"]
             }
         }
     },
@@ -23,7 +23,7 @@
             "metadata": {
                 "uri": "registry.suse.com/suse/sl-micro/6.0/base-iso-image:2.1.1-2.47",
                 "displayName": "SL Micro Base 6.0 ISO",
-                "architectures": ["x86_64","aarch64"]
+                "platforms": ["linux/x86_64","linux/aarch64"]
             }
         }
     }

--- a/channels/sl-micro-60-base.json
+++ b/channels/sl-micro-60-base.json
@@ -9,7 +9,7 @@
             "metadata": {
                 "upgradeImage": "registry.suse.com/suse/sl-micro/6.0/base-os-container:2.1.1-3.18",
                 "displayName": "SL Micro Base 6.0 OS",
-                "architectures": ["amd64","arm64"]
+                "architectures": ["x86_64","aarch64"]
             }
         }
     },
@@ -23,7 +23,7 @@
             "metadata": {
                 "uri": "registry.suse.com/suse/sl-micro/6.0/base-iso-image:2.1.1-2.47",
                 "displayName": "SL Micro Base 6.0 ISO",
-                "architectures": ["amd64","arm64"]
+                "architectures": ["x86_64","aarch64"]
             }
         }
     }

--- a/channels/sl-micro-60-kvm.json
+++ b/channels/sl-micro-60-kvm.json
@@ -9,7 +9,7 @@
             "metadata": {
                 "upgradeImage": "registry.suse.com/suse/sl-micro/6.0/kvm-os-container:2.1.1-3.34",
                 "displayName": "SL Micro KVM 6.0 OS",
-                "architectures": ["x86_64","aarch64"]
+                "platforms": ["linux/x86_64","linux/aarch64"]
             }
         }
     },
@@ -23,7 +23,7 @@
             "metadata": {
                 "uri": "registry.suse.com/suse/sl-micro/6.0/kvm-iso-image:2.1.1-3.46",
                 "displayName": "SL Micro KVM 6.0 ISO",
-                "architectures": ["x86_64","aarch64"]
+                "platforms": ["linux/x86_64","linux/aarch64"]
             }
         }
     }

--- a/channels/sl-micro-60-kvm.json
+++ b/channels/sl-micro-60-kvm.json
@@ -8,7 +8,8 @@
             "type": "container",
             "metadata": {
                 "upgradeImage": "registry.suse.com/suse/sl-micro/6.0/kvm-os-container:2.1.1-3.34",
-                "displayName": "SL Micro KVM 6.0 OS"
+                "displayName": "SL Micro KVM 6.0 OS",
+                "architectures": ["amd64","arm64"]
             }
         }
     },
@@ -21,7 +22,8 @@
             "type": "iso",
             "metadata": {
                 "uri": "registry.suse.com/suse/sl-micro/6.0/kvm-iso-image:2.1.1-3.46",
-                "displayName": "SL Micro KVM 6.0 ISO"
+                "displayName": "SL Micro KVM 6.0 ISO",
+                "architectures": ["amd64","arm64"]
             }
         }
     }

--- a/channels/sl-micro-60-kvm.json
+++ b/channels/sl-micro-60-kvm.json
@@ -9,7 +9,7 @@
             "metadata": {
                 "upgradeImage": "registry.suse.com/suse/sl-micro/6.0/kvm-os-container:2.1.1-3.34",
                 "displayName": "SL Micro KVM 6.0 OS",
-                "architectures": ["amd64","arm64"]
+                "architectures": ["x86_64","aarch64"]
             }
         }
     },
@@ -23,7 +23,7 @@
             "metadata": {
                 "uri": "registry.suse.com/suse/sl-micro/6.0/kvm-iso-image:2.1.1-3.46",
                 "displayName": "SL Micro KVM 6.0 ISO",
-                "architectures": ["amd64","arm64"]
+                "architectures": ["x86_64","aarch64"]
             }
         }
     }

--- a/channels/sl-micro-60-rt.json
+++ b/channels/sl-micro-60-rt.json
@@ -8,7 +8,8 @@
             "type": "container",
             "metadata": {
                 "upgradeImage": "registry.suse.com/suse/sl-micro/6.0/rt-os-container:2.1.1-4.1",
-                "displayName": "SL Micro RT 6.0 OS"
+                "displayName": "SL Micro RT 6.0 OS",
+                "architectures": ["amd64"]
             }
         }
     },
@@ -21,7 +22,8 @@
             "type": "iso",
             "metadata": {
                 "uri": "registry.suse.com/suse/sl-micro/6.0/rt-iso-image:2.1.1-3.29",
-                "displayName": "SL Micro RT 6.0 ISO"
+                "displayName": "SL Micro RT 6.0 ISO",
+                "architectures": ["amd64"]
             }
         }
     }

--- a/channels/sl-micro-60-rt.json
+++ b/channels/sl-micro-60-rt.json
@@ -9,7 +9,7 @@
             "metadata": {
                 "upgradeImage": "registry.suse.com/suse/sl-micro/6.0/rt-os-container:2.1.1-4.1",
                 "displayName": "SL Micro RT 6.0 OS",
-                "architectures": ["x86_64"]
+                "platforms": ["linux/x86_64"]
             }
         }
     },
@@ -23,7 +23,7 @@
             "metadata": {
                 "uri": "registry.suse.com/suse/sl-micro/6.0/rt-iso-image:2.1.1-3.29",
                 "displayName": "SL Micro RT 6.0 ISO",
-                "architectures": ["x86_64"]
+                "platforms": ["linux/x86_64"]
             }
         }
     }

--- a/channels/sl-micro-60-rt.json
+++ b/channels/sl-micro-60-rt.json
@@ -9,7 +9,7 @@
             "metadata": {
                 "upgradeImage": "registry.suse.com/suse/sl-micro/6.0/rt-os-container:2.1.1-4.1",
                 "displayName": "SL Micro RT 6.0 OS",
-                "architectures": ["amd64"]
+                "architectures": ["x86_64"]
             }
         }
     },
@@ -23,7 +23,7 @@
             "metadata": {
                 "uri": "registry.suse.com/suse/sl-micro/6.0/rt-iso-image:2.1.1-3.29",
                 "displayName": "SL Micro RT 6.0 ISO",
-                "architectures": ["amd64"]
+                "architectures": ["x86_64"]
             }
         }
     }

--- a/refresh_channels.sh
+++ b/refresh_channels.sh
@@ -132,6 +132,8 @@ function process_repo() {
         if echo "$raw_inspect_output" | jq '.manifests | length > 0' | grep "true"; then
             architectures=$(echo "$raw_inspect_output" | jq -c '[.manifests[].platform.architecture]')
         fi
+        architectures="${architectures/amd64/x86_64}"
+        architectures="${architectures/arm64/aarch64}"
         local managed_os_version_name=$(format_managed_os_version_name "$flavor" "$tag" "$repo_type")
         # Append entry to intermediate list
         local intermediate_entry="{\"uri\":\"$image_uri\",\"created\":\"$image_creation_date\",\"version\":\"$tag\",\"managedOSVersionName\":\"$managed_os_version_name\",\"displayName\":\"$display_name\",\"architectures\":$architectures}"

--- a/refresh_channels.sh
+++ b/refresh_channels.sh
@@ -129,7 +129,7 @@ function process_repo() {
         local raw_inspect_output=$(skopeo inspect --raw docker://$image_uri)
         # If there is no list of platforms, assume only the one that runs this script is available.
         local platforms="[\"amd64\"]"
-        if echo "$raw_inspect_output" | jq '.manifests | length > 0' | grep "true"; then
+        if echo "$raw_inspect_output" | jq '.manifests | length > 0' | grep "true" > /dev/null; then
             platforms=$(echo "$raw_inspect_output" | jq -c '[.manifests[].platform.architecture]')
         fi
         platforms="${platforms/amd64/linux\/x86_64}"


### PR DESCRIPTION
This PR adds the list of supported architectures.
Normally we expect `amd64` and `arm64`. 
When there are no multiple manifests inspecting the image, we default to `amd64` since by default it's the architecture that the CI agent is running on.