### PR TITLE
Fix gh edit missing base branch

### DIFF
--- a/.github/workflows/refresh-channels.yaml
+++ b/.github/workflows/refresh-channels.yaml
@@ -35,4 +35,4 @@ jobs:
           message="Automatic update. Run ID ${{ github.run_id }}, Number ${{ github.run_number}}, Attempt ${{ github.run_attempt }}"
           git commit -m "${message}" 
           git push --force origin "${{ env.REFRESH_BRANCH }}"
-          gh pr create --fill --head "${{ env.REFRESH_BRANCH }}" || gh pr edit --title "${message}"
+          gh pr create --fill --head "${{ env.REFRESH_BRANCH }}" || gh pr edit --base "${{ env.REFRESH_BRANCH }}" --title "${message}"


### PR DESCRIPTION
Last job fails with 

```
a pull request for branch "gha-automated-refresh" into branch "main" already exists:
https://github.com/rancher/elemental-channels/pull/35
no pull requests found for branch "main"
```

This is related to the line:
```
gh pr create --fill --head "${{ env.REFRESH_BRANCH }}" || gh pr edit --title "${message}"
```

I have the impression that `gh pr edit` does not use the same default base branch as `gh pr create`, so this PR is trying to address that.