### PR TITLE
Limit images on minor versions

### DIFF
--- a/channels/sl-micro-60-baremetal.json
+++ b/channels/sl-micro-60-baremetal.json
@@ -1,20 +1,6 @@
 [
     {
         "metadata": {
-            "name": "baremetal-v2.1.1-3.29-os"
-        },
-        "spec": {
-            "version": "v2.1.1-3.29",
-            "type": "container",
-            "metadata": {
-                "upgradeImage": "registry.suse.com/suse/sl-micro/6.0/baremetal-os-container:2.1.1-3.29",
-                "displayName": "SL Micro 6.0 OS",
-                "platforms": ["linux/x86_64","linux/aarch64"]
-            }
-        }
-    },
-    {
-        "metadata": {
             "name": "baremetal-v2.1.2-3.57-os"
         },
         "spec": {

--- a/channels/sl-micro-60-base.json
+++ b/channels/sl-micro-60-base.json
@@ -1,20 +1,6 @@
 [
     {
         "metadata": {
-            "name": "base-v2.1.1-3.18-os"
-        },
-        "spec": {
-            "version": "v2.1.1-3.18",
-            "type": "container",
-            "metadata": {
-                "upgradeImage": "registry.suse.com/suse/sl-micro/6.0/base-os-container:2.1.1-3.18",
-                "displayName": "SL Micro Base 6.0 OS",
-                "platforms": ["linux/x86_64","linux/aarch64"]
-            }
-        }
-    },
-    {
-        "metadata": {
             "name": "base-v2.1.2-3.34-os"
         },
         "spec": {

--- a/channels/sl-micro-60-kvm.json
+++ b/channels/sl-micro-60-kvm.json
@@ -1,20 +1,6 @@
 [
     {
         "metadata": {
-            "name": "kvm-v2.1.1-3.34-os"
-        },
-        "spec": {
-            "version": "v2.1.1-3.34",
-            "type": "container",
-            "metadata": {
-                "upgradeImage": "registry.suse.com/suse/sl-micro/6.0/kvm-os-container:2.1.1-3.34",
-                "displayName": "SL Micro KVM 6.0 OS",
-                "platforms": ["linux/x86_64","linux/aarch64"]
-            }
-        }
-    },
-    {
-        "metadata": {
             "name": "kvm-v2.1.2-3.51-os"
         },
         "spec": {

--- a/channels/sl-micro-60-rt.json
+++ b/channels/sl-micro-60-rt.json
@@ -1,20 +1,6 @@
 [
     {
         "metadata": {
-            "name": "rt-v2.1.1-4.1-os"
-        },
-        "spec": {
-            "version": "v2.1.1-4.1",
-            "type": "container",
-            "metadata": {
-                "upgradeImage": "registry.suse.com/suse/sl-micro/6.0/rt-os-container:2.1.1-4.1",
-                "displayName": "SL Micro RT 6.0 OS",
-                "platforms": ["linux/x86_64"]
-            }
-        }
-    },
-    {
-        "metadata": {
             "name": "rt-v2.1.2-4.25-os"
         },
         "spec": {


### PR DESCRIPTION
This is a little edit that will make the limit act on minor version `1.2` instead of patch version `1.2.3`.
The goal is to deprecate patch versions faster, since they will have little to no value to stay permanently in the channel.