### PR TITLE
Add min version option

### DIFF
--- a/channels/sl-micro-61-baremetal.json
+++ b/channels/sl-micro-61-baremetal.json
@@ -15,20 +15,6 @@
     },
     {
         "metadata": {
-            "name": "baremetal-v2.1.2-2.30-iso"
-        },
-        "spec": {
-            "version": "v2.1.2-2.30",
-            "type": "iso",
-            "metadata": {
-                "uri": "registry.suse.com/suse/sl-micro/6.1/baremetal-iso-image:2.1.2-2.30",
-                "displayName": "SL Micro 6.1 ISO",
-                "platforms": ["linux/x86_64","linux/aarch64"]
-            }
-        }
-    },
-    {
-        "metadata": {
             "name": "baremetal-v2.2.0-3.7-iso"
         },
         "spec": {

--- a/channels/sl-micro-61-base.json
+++ b/channels/sl-micro-61-base.json
@@ -15,20 +15,6 @@
     },
     {
         "metadata": {
-            "name": "base-v2.1.2-2.26-iso"
-        },
-        "spec": {
-            "version": "v2.1.2-2.26",
-            "type": "iso",
-            "metadata": {
-                "uri": "registry.suse.com/suse/sl-micro/6.1/base-iso-image:2.1.2-2.26",
-                "displayName": "SL Micro Base 6.1 ISO",
-                "platforms": ["linux/x86_64","linux/aarch64"]
-            }
-        }
-    },
-    {
-        "metadata": {
             "name": "base-v2.2.0-3.7-iso"
         },
         "spec": {

--- a/channels/sl-micro-61-kvm.json
+++ b/channels/sl-micro-61-kvm.json
@@ -15,20 +15,6 @@
     },
     {
         "metadata": {
-            "name": "kvm-v2.1.2-2.25-iso"
-        },
-        "spec": {
-            "version": "v2.1.2-2.25",
-            "type": "iso",
-            "metadata": {
-                "uri": "registry.suse.com/suse/sl-micro/6.1/kvm-iso-image:2.1.2-2.25",
-                "displayName": "SL Micro KVM 6.1 ISO",
-                "platforms": ["linux/x86_64","linux/aarch64"]
-            }
-        }
-    },
-    {
-        "metadata": {
             "name": "kvm-v2.2.0-3.9-iso"
         },
         "spec": {

--- a/channels/sl-micro-61-rt.json
+++ b/channels/sl-micro-61-rt.json
@@ -15,20 +15,6 @@
     },
     {
         "metadata": {
-            "name": "rt-v2.1.2-2.26-iso"
-        },
-        "spec": {
-            "version": "v2.1.2-2.26",
-            "type": "iso",
-            "metadata": {
-                "uri": "registry.suse.com/suse/sl-micro/6.1/rt-iso-image:2.1.2-2.26",
-                "displayName": "SL Micro RT 6.1 ISO",
-                "platforms": ["linux/x86_64"]
-            }
-        }
-    },
-    {
-        "metadata": {
             "name": "rt-v2.2.0-3.7-iso"
         },
         "spec": {

--- a/config.yaml
+++ b/config.yaml
@@ -5,21 +5,25 @@ watches:
     osRepo: registry.suse.com/suse/sl-micro/6.1/baremetal-os-container
     isoRepo: registry.suse.com/suse/sl-micro/6.1/baremetal-iso-image
     limit: 1
+    minVersion: "2.2.0"
   - flavor: "kvm"
     fileName: "sl-micro-61-kvm"
     displayName: "SL Micro KVM 6.1"
     osRepo: registry.suse.com/suse/sl-micro/6.1/kvm-os-container
     isoRepo: registry.suse.com/suse/sl-micro/6.1/kvm-iso-image
     limit: 1
+    minVersion: "2.2.0"
   - flavor: "base"
     fileName: "sl-micro-61-base"
     displayName: "SL Micro Base 6.1"
     osRepo: registry.suse.com/suse/sl-micro/6.1/base-os-container
     isoRepo: registry.suse.com/suse/sl-micro/6.1/base-iso-image
     limit: 1
+    minVersion: "2.2.0"
   - flavor: "rt"
     fileName: "sl-micro-61-rt"
     displayName: "SL Micro RT 6.1"
     osRepo: registry.suse.com/suse/sl-micro/6.1/rt-os-container
     isoRepo: registry.suse.com/suse/sl-micro/6.1/rt-iso-image
     limit: 1
+    minVersion: "2.2.0"

--- a/refresh_channels.sh
+++ b/refresh_channels.sh
@@ -138,7 +138,7 @@ function process_repo() {
         local intermediate_list=()
         local img_count=0
         for version in $(list_versions_matching_minor "${repo}" "${minor_version}"); do
-	    # Ingore from this version and on, does not match the minimum criteria
+	    # Ignore from this version and on, does not match the minimum criteria
             is_higher_version "${min_version}" "${version}" && break
 
 	    # Limit the mount of images listed


### PR DESCRIPTION
This PR adds the optional `minVersion` flag in config.yaml which allows to prevent listing any version lower than the given value. For simplicity, this PR also lists and sorts images by tag (aka version) instead of the creation date, this helps to simplify the script and also allows to inspect only the images that will be listed in the channel, which results in a performance improvement if there are many rebuilds of the same image.