### PR TITLE
Update baremental flavor displayName

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,7 @@
 watches: 
   - flavor: "baremetal"
     fileName: "sl-micro-61-baremetal"
-    displayName: "SL Micro 6.1"
+    displayName: "SL Micro Baremetal 6.1"
     osRepo: registry.suse.com/suse/sl-micro/6.1/baremetal-os-container
     isoRepo: registry.suse.com/suse/sl-micro/6.1/baremetal-iso-image
     limit: 1


### PR DESCRIPTION
Having all channels included by default and all of them relating to a flavor, having the displayName for the barmetal flavor without the flavor name is confusing.